### PR TITLE
Add support for all parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ isSpam, err := akismet.Check(akismet.Comment{
 	CommentAuthor: "Billie Joe",
 	CommentAuthorEmail: "billie@example.com",
 	CommentContent: "Something's on my mind",
+	CommentDate: time.Now(),
 }, akismetKey)
 
 if err != nil {

--- a/akismet/akismet.go
+++ b/akismet/akismet.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
-	"reflect"
 	"strings"
 )
 
@@ -14,19 +12,12 @@ import (
 // Therefore, it makes sense to abstract the HTTP request in an unexported
 // function and re-use everywhere.
 func postRequest(c *Comment, key string, endpoint string) (string, error) {
-	form := url.Values{}
-
-	v := reflect.ValueOf(*c)
-	t := v.Type()
-	for i := 0; i < v.Type().NumField(); i++ {
-		if v.Field(i).String() != "" {
-			form.Add(t.Field(i).Tag.Get("form"), v.Field(i).String())
-		}
+	data, err := c.encode()
+	if err != nil {
+		return "", err
 	}
-
 	client := &http.Client{}
-
-	reqBody := strings.NewReader(form.Encode())
+	reqBody := strings.NewReader(data)
 	api := fmt.Sprintf("https://%s.rest.akismet.com/1.1/%s", key, endpoint)
 	req, err := http.NewRequest("POST", api, reqBody)
 	if err != nil {

--- a/akismet/comment.go
+++ b/akismet/comment.go
@@ -1,18 +1,76 @@
 package akismet
 
+import (
+	"errors"
+	"net/url"
+	"time"
+)
+
 type Comment struct {
-	Blog               string `form:"blog"`
-	UserIP             string `form:"user_ip"`
-	UserAgent          string `form:"user_agent"`
-	Referrer           string `form:"referrer"`
-	Permalink          string `form:"permalink"`
-	CommentType        string `form:"comment_type"`
-	CommentAuthor      string `form:"comment_author"`
-	CommentAuthorEmail string `form:"comment_author_email"`
-	CommentAuthorURL   string `form:"comment_author_url"`
-	CommentContent     string `form:"comment_content"`
-	BlogLang           string `form:"blog_lang"`
-	BlogCharset        string `form:"blog_charset"`
-	UserRole           string `form:"user_role"`
-	// TODO: Add support for comment_date_gmt and comment_post_modified_gmt
+	Blog                string
+	UserIP              string
+	UserAgent           string
+	Referrer            string
+	Permalink           string
+	CommentType         string
+	CommentAuthor       string
+	CommentAuthorEmail  string
+	CommentAuthorURL    string
+	CommentContent      string
+	CommentDate         time.Time
+	CommentPostModified time.Time
+	BlogLang            string
+	BlogCharset         string
+	UserRole            string
+	Test                bool
+}
+
+func addOptionalString(v url.Values, key, value string) {
+	if value != "" {
+		v.Add(key, value)
+	}
+}
+
+func addOptionalTime(v url.Values, key string, t time.Time) {
+	if !t.IsZero() {
+		v.Add(key, t.UTC().Format(time.RFC3339))
+	}
+}
+
+func addOptionalBool(v url.Values, key string, value bool) {
+	if value {
+		v.Add(key, "true")
+	}
+}
+
+func (c Comment) encode() (string, error) {
+	if c.Blog == "" {
+		return "", errors.New("Blog field is empty but required")
+	}
+	if c.UserIP == "" {
+		return "", errors.New("UserIP field is empty but required")
+	}
+	if c.UserAgent == "" {
+		return "", errors.New("UserAgent field is empty but required")
+	}
+
+	v := url.Values{}
+	v.Add("blog", c.Blog)
+	v.Add("user_ip", c.UserIP)
+	v.Add("user_agent", c.UserAgent)
+	addOptionalString(v, "referrer", c.Referrer)
+	addOptionalString(v, "permalink", c.Permalink)
+	addOptionalString(v, "comment_type", c.CommentType)
+	addOptionalString(v, "comment_author", c.CommentAuthor)
+	addOptionalString(v, "comment_author_email", c.CommentAuthorEmail)
+	addOptionalString(v, "comment_author_url", c.CommentAuthorURL)
+	addOptionalString(v, "comment_content", c.CommentContent)
+	addOptionalTime(v, "comment_date_gmt", c.CommentDate)
+	addOptionalTime(v, "comment_post_modified_gmt", c.CommentPostModified)
+	addOptionalString(v, "blog_lang", c.BlogLang)
+	addOptionalString(v, "blog_charset", c.BlogCharset)
+	addOptionalString(v, "user_role", c.UserRole)
+	addOptionalBool(v, "is_test", c.Test)
+
+	return v.Encode(), nil
 }

--- a/akismet/comment_check_test.go
+++ b/akismet/comment_check_test.go
@@ -3,6 +3,7 @@ package akismet
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 var chromeUA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.146 Safari/537.36"
@@ -57,7 +58,7 @@ func testInvalids(t *testing.T, key string) {
 
 		testCaseCheck{
 			"Comment{} missing blog",
-			Comment{UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: "Hello!"},
+			Comment{Test: true, UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: "Hello!"},
 			true,
 			true,
 		},
@@ -70,21 +71,21 @@ func testSpam(t *testing.T, key string) {
 	testCases := []testCaseCheck{
 		testCaseCheck{
 			"Typical 419 scam",
-			Comment{Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: "Send $6,321 to my western union account and receive $1,000,000 today http://419.com http://419.com"},
+			Comment{Test: true, Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: "Send $6,321 to my western union account and receive $1,000,000 today http://419.com http://419.com"},
 			true,
 			false,
 		},
 
 		testCaseCheck{
 			"Outed by user agent",
-			Comment{Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: "Python-urllib/2.1", CommentContent: notSpam},
+			Comment{Test: true, Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: "Python-urllib/2.1", CommentContent: notSpam},
 			true,
 			false,
 		},
 
 		testCaseCheck{
 			"Known to be a spammer by email",
-			Comment{Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: notSpam, CommentAuthorEmail: "akismet-guaranteed-spam@example.com"},
+			Comment{Test: true, Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: notSpam, CommentAuthorEmail: "akismet-guaranteed-spam@example.com"},
 			true,
 			false,
 		},
@@ -97,7 +98,7 @@ func testHam(t *testing.T, key string) {
 	testCases := []testCaseCheck{
 		testCaseCheck{
 			"Comment{} missing blog",
-			Comment{Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: notSpam},
+			Comment{Test: true, Blog: "https://example.com", UserIP: "8.8.8.8", UserAgent: chromeUA, CommentContent: notSpam, CommentDate: time.Now()},
 			false,
 			false,
 		},

--- a/akismet/doc.go
+++ b/akismet/doc.go
@@ -17,6 +17,7 @@ not using the akismet.Check method:
 		CommentAuthor: "Billie Joe",
 		CommentAuthorEmail: "billie@example.com",
 		CommentContent: "Something's on my mind",
+		CommentDate: time.Now(),
 	}, akismetKey)
 
 	if err != nil {


### PR DESCRIPTION
Hello!

This PR does a few things:
* Adds support for `comment_date_gmt`, `comment_post_modified_gmt`, `is_test` parameters.
* Tests now use the `is_test` paramater.
* Refactored the `Comment` struct serialization in a way that doesn't depend on `reflect` to win big on performance.
* Added local checks for required fields.

Fixes #1